### PR TITLE
add secret option to param named for token

### DIFF
--- a/lib/fluent/plugin/in_slackrtm.rb
+++ b/lib/fluent/plugin/in_slackrtm.rb
@@ -6,7 +6,7 @@ module Fluent
     Fluent::Plugin.register_input('slackrtm', self)
 
     config_param :tag, :string
-    config_param :token, :string
+    config_param :token, :string, :secret => true
 
     def start
       super


### PR DESCRIPTION
A param `token` must be sensitive.
So add `:secret` option.

ref
http://www.slideshare.net/repeatedly/fluentd-v012-master-guide
